### PR TITLE
Phase 4A: replace string-based csproj parsing with XDocument

### DIFF
--- a/Mirid.Core/Models/MFPackageProject.cs
+++ b/Mirid.Core/Models/MFPackageProject.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+using System;
+using System.IO;
+using System.Xml.Linq;
 
 namespace Mirid.Models
 {
@@ -12,14 +14,11 @@ namespace Mirid.Models
         public string Version { get; private set; }
         public string Authors { get; private set; }
 
-        //private
-        string projectText;
-        FileInfo fileInfo;
+        readonly FileInfo fileInfo;
 
         public MFPackageProject(FileInfo fileInfo)
         {
             this.fileInfo = fileInfo;
-            LoadDriverText(fileInfo.FullName);
             ParseElements();
         }
 
@@ -35,60 +34,39 @@ namespace Mirid.Models
             return true;
         }
 
-        //could do this on demand but I'm not really worried about memory
         void ParseElements()
         {
-            AssemblyName = GetElement("AssemblyName");
-            CompanyName = GetElement("Company");
-            Version = GetElement("Version");
-            PackageId = GetElement("PackageId");
-            Description = GetElement("Description");
-            GeneratePackageOnBuild = GetElement("GeneratePackageOnBuild");
-            Authors = GetElement("Authors");
+            if (!File.Exists(fileInfo.FullName))
+            {
+                throw new FileNotFoundException($"Couldn't find driver project {fileInfo.FullName}");
+            }
+
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Load(fileInfo.FullName);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error parsing project file {fileInfo.FullName}: {ex.Message}");
+                return;
+            }
+
+            AssemblyName = GetElement(doc, "AssemblyName");
+            CompanyName = GetElement(doc, "Company");
+            Version = GetElement(doc, "Version");
+            PackageId = GetElement(doc, "PackageId");
+            Description = GetElement(doc, "Description");
+            GeneratePackageOnBuild = GetElement(doc, "GeneratePackageOnBuild");
+            Authors = GetElement(doc, "Authors");
 
             if (string.IsNullOrWhiteSpace(PackageId))
             {
-                //parse the project name
                 PackageId = "Meadow.Foundation." + Path.GetFileNameWithoutExtension(fileInfo.Name);
             }
         }
 
-        void LoadDriverText(string path)
-        {
-            if (File.Exists(path) == false)
-            {
-                throw new FileNotFoundException($"Couldn't find driver project {path}");
-            }
-
-            try
-            {
-                projectText = File.ReadAllText(path);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error reading project file {path}: {ex.Message}");
-                projectText = string.Empty;
-            }
-        }
-
-        string GetElement(string element)
-        {
-            int index = projectText.IndexOf(element);
-
-            if (index == -1)
-            {
-                return string.Empty;
-            }
-
-            int start = projectText.IndexOf(">", index) + 1;
-            int end = projectText.IndexOf("<", start);
-
-            if (start <= 0 || end < 0 || end <= start)
-            {
-                return string.Empty;
-            }
-
-            return projectText.Substring(start, end - start);
-        }
+        static string GetElement(XDocument doc, string elementName)
+            => doc.Descendants(elementName).FirstOrDefault()?.Value ?? string.Empty;
     }
 }

--- a/Mirid.Core/ProjectWriter.cs
+++ b/Mirid.Core/ProjectWriter.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.IO;
 using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
 
 namespace Mirid
 {
@@ -11,321 +12,193 @@ namespace Mirid
         {
             if (project == null || !File.Exists(project.FullName)) return false;
 
-            List<string> lines;
-            try { lines = File.ReadAllLines(project.FullName).ToList(); }
-            catch (Exception ex) { Console.WriteLine($"Error reading {project.FullName}: {ex.Message}"); return false; }
-
-            var indexes = new List<int>();
-
-            for (int i = 0; i < lines.Count; i++)
+            XDocument doc;
+            XElement newElement;
+            try
             {
-                //if (lines[i].Contains(reference))
-                {   //already have it
-                    //    return true;
-                }
-                if (lines[i].Contains(lineMatch))
+                doc = XDocument.Load(project.FullName);
+                newElement = XElement.Parse(reference.Trim());
+            }
+            catch (Exception ex) { Console.WriteLine($"Error loading {project.FullName}: {ex.Message}"); return false; }
+
+            var matches = doc.Descendants()
+                .Where(e => e.Attributes().Any(a => a.Value.Contains(lineMatch)))
+                .ToList();
+
+            if (matches.Any())
+            {
+                matches[0].ReplaceWith(newElement);
+                for (int i = 1; i < matches.Count; i++)
+                    matches[i].Remove();
+            }
+            else
+            {
+                var itemGroup = doc.Root.Elements("ItemGroup").FirstOrDefault();
+                if (itemGroup == null)
                 {
-                    indexes.Add(i);
-                    //  lines[i] = reference;
-                    //  File.WriteAllLines(project.FullName, lines.ToArray());
-                    //  return true;
+                    itemGroup = new XElement("ItemGroup");
+                    doc.Root.Add(itemGroup);
                 }
+                itemGroup.AddFirst(newElement);
             }
 
-            bool found = false;
-            foreach (var index in indexes)
-            {
-                if (found == false)
-                {
-                    lines[index] = reference;
-                    found = true;
-                }
-                else
-                {
-                    lines.RemoveAt(index);
-                    break;
-                }
-            }
-
-            if (found == true)
-            {
-                try { File.WriteAllLines(project.FullName, lines.ToArray()); }
-                catch (Exception ex) { Console.WriteLine($"Error writing {project.FullName}: {ex.Message}"); return false; }
-                return true;
-            }
-
-            //find references 
-            int indexItemGroup = -1;
-            int indexCloseProject = -1;
-
-            for (int i = 0; i < lines.Count; i++)
-            {
-                if (lines[i].Contains("<ItemGroup>"))
-                {
-                    indexItemGroup = i;
-                    break;
-                }
-                if (lines[i].Contains("</Project>"))
-                {
-                    indexCloseProject = i;
-                }
-            }
-
-            if (indexItemGroup == -1)
-            {
-                lines.Insert(indexCloseProject, $"  </ItemGroup>");
-                lines.Insert(indexCloseProject, $"  <ItemGroup>");
-                indexItemGroup = indexCloseProject;
-            }
-
-            //insert
-            lines.Insert(indexItemGroup + 1, reference);
-
-            try { File.WriteAllLines(project.FullName, lines.ToArray()); }
-            catch (Exception ex) { Console.WriteLine($"Error writing {project.FullName}: {ex.Message}"); return false; }
-
-            return true;
+            return SaveDocument(doc, project.FullName);
         }
 
         public static bool AddReference(FileInfo project, string reference)
         {
             if (project == null || !File.Exists(project.FullName)) return false;
 
-            List<string> lines;
-            try { lines = File.ReadAllLines(project.FullName).ToList(); }
-            catch (Exception ex) { Console.WriteLine($"Error reading {project.FullName}: {ex.Message}"); return false; }
-
-            for (int i = 0; i < lines.Count; i++)
+            XDocument doc;
+            XElement newElement;
+            try
             {
-                if (lines[i].Contains(reference))
-                {   //already have it
-                    return true;
-                }
+                doc = XDocument.Load(project.FullName);
+                newElement = XElement.Parse(reference.Trim());
+            }
+            catch (Exception ex) { Console.WriteLine($"Error loading {project.FullName}: {ex.Message}"); return false; }
+
+            var includeValue = newElement.Attribute("Include")?.Value;
+            if (includeValue != null &&
+                doc.Descendants().Any(e => e.Attribute("Include")?.Value == includeValue))
+            {
+                return true; // already present
             }
 
-            //find references 
-            int indexItemGroup = -1;
-            int indexCloseProject = -1;
-
-            for (int i = 0; i < lines.Count; i++)
+            var itemGroup = doc.Root.Elements("ItemGroup").FirstOrDefault();
+            if (itemGroup == null)
             {
-                if (lines[i].Contains("<ItemGroup>"))
-                {
-                    indexItemGroup = i;
-                    break;
-                }
-                if (lines[i].Contains("</Project>"))
-                {
-                    indexCloseProject = i;
-                }
+                itemGroup = new XElement("ItemGroup");
+                doc.Root.Add(itemGroup);
             }
+            itemGroup.AddFirst(newElement);
 
-            if (indexItemGroup == -1)
-            {
-                lines.Insert(indexCloseProject, $"  </ItemGroup>");
-                lines.Insert(indexCloseProject, $"  <ItemGroup>");
-                indexItemGroup = indexCloseProject;
-            }
-
-            //insert
-            lines.Insert(indexItemGroup + 1, reference);
-
-            try { File.WriteAllLines(project.FullName, lines.ToArray()); }
-            catch (Exception ex) { Console.WriteLine($"Error writing {project.FullName}: {ex.Message}"); return false; }
-
-            return true;
+            return SaveDocument(doc, project.FullName);
         }
 
         public static bool AddReference(FileInfo project, FileInfo reference)
         {
-            if (project == null || reference == null)
-            {
-                return false;
-            }
+            if (project == null || reference == null) return false;
 
             var relativePath = Path.GetRelativePath(Path.GetDirectoryName(project.FullName), reference.FullName);
-            return AddReference(project, $"    <ProjectReference Include=\"{relativePath}\"/>");
+            return AddReference(project, $"<ProjectReference Include=\"{relativePath}\"/>");
         }
 
         public static bool AddNuget(FileInfo project, string packageName)
         {
             if (project == null || !File.Exists(project.FullName)) return false;
 
-            List<string> lines;
-            try { lines = File.ReadAllLines(project.FullName).ToList(); }
-            catch (Exception ex) { Console.WriteLine($"Error reading {project.FullName}: {ex.Message}"); return false; }
+            XDocument doc;
+            try { doc = XDocument.Load(project.FullName); }
+            catch (Exception ex) { Console.WriteLine($"Error loading {project.FullName}: {ex.Message}"); return false; }
 
-            //find references 
-            int indexItemGroup = -1;
-            int indexCloseProject = -1;
+            var newElement = new XElement("PackageReference",
+                new XAttribute("Include", packageName),
+                new XAttribute("Version", "0.*"));
 
-            for (int i = 0; i < lines.Count; i++)
+            // Prefer the ItemGroup that already has ProjectReferences
+            var itemGroup = doc.Descendants("ProjectReference").FirstOrDefault()?.Parent
+                         ?? doc.Root.Elements("ItemGroup").FirstOrDefault();
+
+            if (itemGroup == null)
             {
-                if (lines[i].Contains("<ProjectReference"))
-                {
-                    indexItemGroup = i - 1;
-                }
-                if (lines[i].Contains("</Project>"))
-                {
-                    indexCloseProject = i;
-                }
+                itemGroup = new XElement("ItemGroup");
+                doc.Root.Add(itemGroup);
             }
+            itemGroup.AddFirst(newElement);
 
-            if (indexItemGroup == -1)
-            {
-                lines.Insert(indexCloseProject, $"  </ItemGroup>");
-                lines.Insert(indexCloseProject, $"  <ItemGroup>");
-                indexItemGroup = indexCloseProject;
-            }
-
-            var reference = $"   <PackageReference Include=\"{packageName}\" Version=\"0.*\" />";
-
-            //insert
-            lines.Insert(indexItemGroup + 1, reference);
-
-            try { File.WriteAllLines(project.FullName, lines.ToArray()); }
-            catch (Exception ex) { Console.WriteLine($"Error writing {project.FullName}: {ex.Message}"); return false; }
-
-            return true;
+            return SaveDocument(doc, project.FullName);
         }
 
         public static bool RemoveReference(FileInfo project, FileInfo reference)
         {
-            if (project == null || reference == null)
-            {
-                return false;
-            }
+            if (project == null || reference == null) return false;
 
-            List<string> lines;
-            try { lines = File.ReadAllLines(project.FullName).ToList(); }
-            catch (Exception ex) { Console.WriteLine($"Error reading {project.FullName}: {ex.Message}"); return false; }
+            XDocument doc;
+            try { doc = XDocument.Load(project.FullName); }
+            catch (Exception ex) { Console.WriteLine($"Error loading {project.FullName}: {ex.Message}"); return false; }
 
-            //find references 
-            for (int i = 0; i < lines.Count; i++)
-            {
-                if (lines[i].Contains(reference.FullName))
-                {
-                    lines.RemoveAt(i);
-                }
-            }
+            var toRemove = doc.Descendants("ProjectReference")
+                .Where(e => e.Attribute("Include")?.Value.Contains(reference.FullName) == true)
+                .ToList();
 
-            try { File.WriteAllLines(project.FullName, lines.ToArray()); }
-            catch (Exception ex) { Console.WriteLine($"Error writing {project.FullName}: {ex.Message}"); return false; }
+            foreach (var el in toRemove) el.Remove();
 
-            return true;
+            return SaveDocument(doc, project.FullName);
         }
 
         public static bool DeleteProperty(FileInfo file, string property)
         {
             if (file == null || !File.Exists(file.FullName)) return false;
 
-            List<string> lines;
-            try { lines = File.ReadAllLines(file.FullName).ToList(); }
-            catch (Exception ex) { Console.WriteLine($"Error reading {file.FullName}: {ex.Message}"); return false; }
+            XDocument doc;
+            try { doc = XDocument.Load(file.FullName); }
+            catch (Exception ex) { Console.WriteLine($"Error loading {file.FullName}: {ex.Message}"); return false; }
 
-            //find property
-            for (int i = 0; i < lines.Count; i++)
-            {
-                if (lines[i].Contains($"<{property}>"))
-                {
-                    lines.RemoveAt(i);
-                    break;
-                }
-            }
+            doc.Descendants(property).FirstOrDefault()?.Remove();
 
-            try { File.WriteAllLines(file.FullName, lines.ToArray()); }
-            catch (Exception ex) { Console.WriteLine($"Error writing {file.FullName}: {ex.Message}"); return false; }
-
-            return true;
+            return SaveDocument(doc, file.FullName);
         }
 
         public static bool AddUpdateProperty(FileInfo file, string property, string value)
         {
             if (file == null || !File.Exists(file.FullName)) return false;
 
-            List<string> lines;
-            try { lines = File.ReadAllLines(file.FullName).ToList(); }
-            catch (Exception ex) { Console.WriteLine($"Error reading {file.FullName}: {ex.Message}"); return false; }
+            XDocument doc;
+            try { doc = XDocument.Load(file.FullName); }
+            catch (Exception ex) { Console.WriteLine($"Error loading {file.FullName}: {ex.Message}"); return false; }
 
-            List<int> indexes = new();
+            var propGroup = doc.Root.Elements("PropertyGroup").FirstOrDefault();
+            if (propGroup == null) return false;
 
-            int indexProperyGroup = -1;
-            for (int i = 0; i < lines.Count; i++)
-            {
-                if (indexProperyGroup == -1 && lines[i].Contains("<PropertyGroup>"))
-                {
-                    indexProperyGroup = i;
-                }
-                else if (lines[i].Contains($"<{property}>"))
-                {
-                    if (lines[i].Contains($">{value}<"))
-                    {
-                        //   return true;
-                    }
+            // Remove duplicates, keep first
+            var existing = propGroup.Elements(property).ToList();
+            for (int i = 1; i < existing.Count; i++) existing[i].Remove();
 
-                    indexes.Add(i);
-                }
-            }
+            if (existing.Any())
+                existing[0].Value = value;
+            else
+                propGroup.AddFirst(new XElement(property, value));
 
-            if (indexProperyGroup == -1)
-            {
-                return false;
-            }
-
-            bool found = false;
-
-            foreach (var index in indexes)
-            {
-                if (found)
-                {   //only good for one duplicate
-                    lines.RemoveAt(index);
-                    break;
-                }
-
-                if (lines[index].Contains($"<{property}>") == true)
-                {
-                    found = true;
-                    lines[index] = $"    <{property}>{value}</{property}>";
-                }
-            }
-
-            //add if it doesn't exist
-            if (found == false)
-            {
-                lines.Insert(indexProperyGroup + 1, $"    <{property}>{value}</{property}>");
-            }
-
-            try { File.WriteAllLines(file.FullName, lines.ToArray()); }
-            catch (Exception ex) { Console.WriteLine($"Error writing {file.FullName}: {ex.Message}"); return false; }
-
-            return true;
+            return SaveDocument(doc, file.FullName);
         }
 
         public static bool RemoveMeadowConfig(FileInfo file)
         {
             if (file == null || !File.Exists(file.FullName)) return false;
 
-            List<string> lines;
-            try { lines = File.ReadAllLines(file.FullName).ToList(); }
-            catch (Exception ex) { Console.WriteLine($"Error reading {file.FullName}: {ex.Message}"); return false; }
+            XDocument doc;
+            try { doc = XDocument.Load(file.FullName); }
+            catch (Exception ex) { Console.WriteLine($"Error loading {file.FullName}: {ex.Message}"); return false; }
 
-            for (int i = 0; i < lines.Count; i++)
+            var meadowConfigGroup = doc.Descendants("None")
+                .Where(e => e.Attribute("Update")?.Value == "meadow.config.yaml")
+                .Select(e => e.Parent)
+                .FirstOrDefault();
+
+            if (meadowConfigGroup != null)
             {
-                if (lines[i].Contains("ItemGroup") &&
-                    lines[i + 1].Contains("Update=\"meadow.config.yaml") &&
-                    lines[i + 2].Contains("CopyToOutputDirectory") &&
-                    lines[i + 3].Contains("None") &&
-                    lines[i + 4].Contains("ItemGroup"))
-                {
-                    //delete 5 lines
-                    lines.RemoveRange(i, 5);
-
-                    try { File.WriteAllLines(file.FullName, lines.ToArray()); }
-                    catch (Exception ex) { Console.WriteLine($"Error writing {file.FullName}: {ex.Message}"); return false; }
-                }
+                meadowConfigGroup.Remove();
+                return SaveDocument(doc, file.FullName);
             }
 
             return true;
+        }
+
+        static bool SaveDocument(XDocument doc, string path)
+        {
+            try
+            {
+                var settings = new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true };
+                using var writer = XmlWriter.Create(path, settings);
+                doc.Save(writer);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error writing {path}: {ex.Message}");
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
MFPackageProject: replace IndexOf/Substring element extraction with XDocument.Load + Descendants LINQ queries. Removes raw text field, LoadDriverText, and string-based GetElement.

ProjectWriter: replace all line-based XML manipulation with XDocument. All methods now load/modify/save as proper XML. SaveDocument helper omits XML declaration and uses indented output.

Assisted by Claude Sonnet 4.6