### PR TITLE
Phase 4B: replace string-based namespace extraction with Roslyn

### DIFF
--- a/Mirid/Mirid.csproj
+++ b/Mirid/Mirid.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="19.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mirid/Models/MFDriverCode.cs
+++ b/Mirid/Models/MFDriverCode.cs
@@ -1,4 +1,7 @@
 ﻿using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Mirid.Models
 {
@@ -49,13 +52,22 @@ namespace Mirid.Models
 
         string GetNamespace()
         {
-            foreach (var line in lines)
-            {
-                if (line.Contains("namespace"))
-                {
-                    return line.Substring("namespace ".Length).TrimEnd(';');
-                }
-            }
+            if (!File.Exists(Path)) return string.Empty;
+
+            var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(Path));
+            var root = tree.GetRoot();
+
+            var fileScopedNs = root.DescendantNodes()
+                .OfType<FileScopedNamespaceDeclarationSyntax>()
+                .FirstOrDefault();
+            if (fileScopedNs != null)
+                return fileScopedNs.Name.ToString();
+
+            var blockNs = root.DescendantNodes()
+                .OfType<NamespaceDeclarationSyntax>()
+                .FirstOrDefault();
+            if (blockNs != null)
+                return blockNs.Name.ToString();
 
             return string.Empty;
         }


### PR DESCRIPTION
Replace fragile line.Contains("namespace") substring hack with CSharpSyntaxTree.ParseText() — handles both block-scoped and file-scoped namespace declarations correctly.