### PR TITLE
Fix null-ref crashes and fragile header table logic

### DIFF
--- a/Mirid.Core/Models/MFDriverSample.cs
+++ b/Mirid.Core/Models/MFDriverSample.cs
@@ -24,29 +24,20 @@
 
         public string GetSnipSnop()
         {
+            if (meadowAppFileInfo == null || !File.Exists(meadowAppFileInfo.FullName))
+                return string.Empty;
+
             var text = File.ReadAllText(meadowAppFileInfo.FullName);
 
             int snipIndex = text.IndexOf(SNIP);
             int snopIndex = text.IndexOf(SNOP);
 
-            if(snipIndex == -1 || snopIndex == -1)
-            {
+            if (snipIndex == -1 || snopIndex == -1)
                 return string.Empty;
-            }
 
             snipIndex += SNIP.Length;
 
             return text.Substring(snipIndex, snopIndex - snipIndex);
-        }
-
-        string LoadFileText(string path)
-        {
-            if (File.Exists(path) == false)
-            {
-                throw new FileNotFoundException($"Couldn't find file {path}");
-            }
-
-            return File.ReadAllText(path);
         }
     }
 }

--- a/Mirid/Models/MFDriverDocumentation.cs
+++ b/Mirid/Models/MFDriverDocumentation.cs
@@ -175,40 +175,39 @@ namespace Mirid.Models
 
         public void UpdateDocHeader(string packageName, string githubCodeUrl, string githubDatasheetUrl = null)
         {
-            //split by line
+            if (string.IsNullOrWhiteSpace(text)) return;
+
             var lines = text.Split(new[] { Environment.NewLine }, StringSplitOptions.None).ToList();
 
-            bool isTableStarted = false;
-            int tableLineStart = 5;
-            int tableLineEnd = 0;
+            int tableLineStart = -1;
+            int tableLineEnd = -1;
 
             for (int i = 0; i < lines.Count; i++)
             {
-                //find first | 
-                if (isTableStarted == false &&
-                    lines[i].Length > 0 &&
-                    lines[i][0] == '|')
+                if (lines[i].Length > 0 && lines[i][0] == '|')
                 {
-                    isTableStarted = true;
-                    tableLineStart = i;
-                }
-                else if (isTableStarted == true &&
-                    lines[i].Length > 0 &&
-                    lines[i][0] == '|')
-                {
+                    if (tableLineStart == -1) tableLineStart = i;
                     tableLineEnd = i;
                 }
-                else if (isTableStarted == true)
+                else if (tableLineStart != -1)
                 {
                     break;
                 }
             }
 
-            //delete the header table
-            for (int i = 0; i < tableLineEnd - tableLineStart + 1; i++)
+            if (tableLineStart == -1)
             {
-                lines.RemoveAt(tableLineStart);
+                // No existing table — insert after the front-matter block (first blank line after ---)
+                tableLineStart = lines.FindIndex(l => l.TrimStart().StartsWith("---")) + 1;
+                while (tableLineStart < lines.Count && string.IsNullOrWhiteSpace(lines[tableLineStart]))
+                    tableLineStart++;
+                tableLineEnd = tableLineStart - 1;
             }
+
+            // Remove existing table rows
+            int rowCount = tableLineEnd - tableLineStart + 1;
+            for (int i = 0; i < rowCount; i++)
+                lines.RemoveAt(tableLineStart);
 
             //create the table 
             var table = new List<string>

--- a/Mirid/Models/MFPackage.cs
+++ b/Mirid/Models/MFPackage.cs
@@ -40,7 +40,7 @@ namespace Mirid.Models
 
 
         [Ignore]
-        public string Namespace => Drivers.First().Namespace;
+        public string Namespace => Drivers.FirstOrDefault()?.Namespace ?? string.Empty;
 
         [Ignore] //ToDo LINQ expression from driver list - count of drivers that have samples 
         public List<string> Samples { get; protected set; } = new List<string>();


### PR DESCRIPTION
- MFDriverSample.GetSnipSnop: guard against null/missing meadowAppFileInfo
- MFPackage.Namespace: FirstOrDefault instead of First to avoid empty-list throw
- MFDriverDocumentation.UpdateDocHeader: fix tableLineEnd defaulting to 0 when no table exists; fall back to inserting after front-matter instead of silently corrupting line 0