### PR TITLE
Fix nullable warnings, dead code, and RemoveMeadowConfig scope bug

### DIFF
--- a/Mirid.Core/ProjectWriter.cs
+++ b/Mirid.Core/ProjectWriter.cs
@@ -171,14 +171,19 @@ namespace Mirid
             try { doc = XDocument.Load(file.FullName); }
             catch (Exception ex) { Console.WriteLine($"Error loading {file.FullName}: {ex.Message}"); return false; }
 
-            var meadowConfigGroup = doc.Descendants("None")
+            var meadowConfigElement = doc.Descendants("None")
                 .Where(e => e.Attribute("Update")?.Value == "meadow.config.yaml")
-                .Select(e => e.Parent)
                 .FirstOrDefault();
 
-            if (meadowConfigGroup != null)
+            if (meadowConfigElement != null)
             {
-                meadowConfigGroup.Remove();
+                var parent = meadowConfigElement.Parent;
+                meadowConfigElement.Remove();
+
+                // Clean up the ItemGroup if it's now empty
+                if (parent != null && !parent.HasElements)
+                    parent.Remove();
+
                 return SaveDocument(doc, file.FullName);
             }
 

--- a/Mirid.Core/Validations.cs
+++ b/Mirid.Core/Validations.cs
@@ -22,9 +22,5 @@
             return exists;
         }
 
-        public static bool IsProjectInMatchingFolder(FileInfo projectFile)
-        {
-            return false;
-        }
     }
 }

--- a/Mirid/Models/MFDriverDocumentation.cs
+++ b/Mirid/Models/MFDriverDocumentation.cs
@@ -21,7 +21,6 @@ namespace Mirid.Models
         readonly MFDriver driver;
         readonly string documentationPath;
         string text;
-        string simpleNamespace;
 
 
         public MFDriverDocumentation(MFDriver driver, string docsPath)
@@ -34,19 +33,7 @@ namespace Mirid.Models
 
         public void ReadDocsFile()
         {
-            //  var override = Path.Combine()
             var simpleName = driver.SimpleName;
-
-            var index = "Meadow.Foundation.".Length;
-
-            if (driver.Namespace.Contains("Grove"))
-            {
-                simpleNamespace = driver.Name;
-            }
-            else
-            {
-                simpleNamespace = driver.Namespace[index..] + "." + driver.SimpleName;
-            }
 
             DocsFileName = driver.Namespace + "." + simpleName + ".md";
             FullPath = Path.Combine(documentationPath, DocsFileName);

--- a/Mirid/Models/MFPackage.cs
+++ b/Mirid/Models/MFPackage.cs
@@ -92,9 +92,7 @@ namespace Mirid.Models
             else
             {
                 var fileName = GetSimpleName(driverProjectFile.Name) + ".cs";
-                var file = Path.Combine(driverProjectFile.DirectoryName, fileName);
-
-                var fullName = Path.GetFileNameWithoutExtension(driverProjectFile.Name);
+                var file = Path.Combine(driverProjectFile.DirectoryName ?? string.Empty, fileName);
                 Drivers.Add(new MFDriver(this,
                                          file,
                                          Assets.GetSampleForName(Path.GetFileNameWithoutExtension(file) + "_Sample"),


### PR DESCRIPTION
- MFPackage: null-coalesce DirectoryName, remove unused fullName variable
- MFDriverDocumentation: remove simpleNamespace field and assignments (computed but never read)
- ProjectWriter.RemoveMeadowConfig: remove only the <None> element, not the entire parent <ItemGroup>; clean up the group only if left empty
- Validations: remove IsProjectInMatchingFolder stub (always returned false, never called)