### PR TITLE
Phase 6: fix null-ref and bounds crashes

### DIFF
--- a/ExternalRefReaper/RefReaper.cs
+++ b/ExternalRefReaper/RefReaper.cs
@@ -37,11 +37,12 @@
                     {
                         lines.RemoveAt(index);
 
-                        if (lines[index].Contains("EndProject"))
+                        if (index < lines.Count && lines[index].Contains("EndProject"))
                         {
                             lines.RemoveAt(index);
                         }
                         foundGuid = true;
+                        break;
                     }
                 }
 

--- a/Mirid.Core/Models/MFDriverSample.cs
+++ b/Mirid.Core/Models/MFDriverSample.cs
@@ -37,6 +37,9 @@
 
             snipIndex += SNIP.Length;
 
+            if (snopIndex <= snipIndex)
+                return string.Empty;
+
             return text.Substring(snipIndex, snopIndex - snipIndex);
         }
     }

--- a/Mirid.Core/Validations.cs
+++ b/Mirid.Core/Validations.cs
@@ -4,7 +4,7 @@
     {
         public static bool DoesProjectContainMatchingClass(FileInfo projectFile)
         {
-            var driverName = projectFile.Name.Substring(0, projectFile.Name.IndexOf(".csproj"));
+            var driverName = Path.GetFileNameWithoutExtension(projectFile.Name);
             driverName = driverName.Substring(driverName.LastIndexOf(".") + 1);
 
             var directory = projectFile.Directory;

--- a/Mirid/Models/MFDriver.cs
+++ b/Mirid/Models/MFDriver.cs
@@ -47,7 +47,7 @@ namespace Mirid.Models
         public string DatasheetPath => "";
 
         [Ignore]
-        public string SamplePath => driverSample.DirectoryInfo.FullName;
+        public string SamplePath => driverSample?.DirectoryInfo.FullName ?? string.Empty;
 
         [Ignore]
         public string SimpleName => driverCode.Name.Split('.').LastOrDefault();

--- a/Mirid/Models/MFDriverDocumentation.cs
+++ b/Mirid/Models/MFDriverDocumentation.cs
@@ -221,7 +221,8 @@ namespace Mirid.Models
             }
 
             //remove the trailing empty line
-            lines.RemoveAt(lines.Count - 1);
+            if (lines.Count > 0)
+                lines.RemoveAt(lines.Count - 1);
 
             try { File.WriteAllLines(FullPath, lines); }
             catch (Exception ex) { Console.WriteLine($"Error writing docs file {FullPath}: {ex.Message}"); return; }

--- a/Mirid/Models/MFPackage.cs
+++ b/Mirid/Models/MFPackage.cs
@@ -104,6 +104,9 @@ namespace Mirid.Models
         {
             var nameChunks = Name.Split('.');
 
+            if (nameChunks.Length < 2)
+                return Path.GetFileNameWithoutExtension(Name);
+
             return nameChunks[nameChunks.Length - 2];
         }
     }

--- a/ReferenceSwitcher/RefSwitcher.cs
+++ b/ReferenceSwitcher/RefSwitcher.cs
@@ -222,7 +222,7 @@ namespace ReferenceSwitcher
         {
             if (fileInfoToModify == null)
             {
-                Console.WriteLine($"{fileInfoToModify} is null");
+                Console.WriteLine($"fileInfoToModify is null (packageId: {packageId})");
                 return;
             }
 


### PR DESCRIPTION
- MFDriver.SamplePath: null-coalesce driverSample to avoid crash when no sample
- MFDriverDocumentation.UpdateDocHeader: guard RemoveAt on empty lines list
- RefReaper.RemoveExternalRefs: bounds-check lines[index] after RemoveAt; add break to prevent double-remove if multiple guids match one line
- RefSwitcher.ReplaceNugetRefWithLocalRef: fix useless null log message (printed null, not the variable name); return was already present
- MFPackage.GetSimpleName: guard nameChunks[Length-2] when name has no dots
- MFDriverSample.GetSnipSnop: return empty if SNOP appears before SNIP (negative length)
- Validations.DoesProjectContainMatchingClass: use Path.GetFileNameWithoutExtension instead of IndexOf(".csproj") which returns -1 on malformed input