### PR TITLE
Phase 7: fix hardcoded paths and XML parsing in satellite tools

### DIFF
--- a/ActionGen/Program.cs
+++ b/ActionGen/Program.cs
@@ -1,4 +1,6 @@
-﻿namespace ActionGen
+﻿using System.Xml.Linq;
+
+namespace ActionGen
 {
     class Program
     {
@@ -65,38 +67,21 @@
 
         static (int refCount, string packageId) GetMetaData(FileInfo projectFile)
         {
-            string text = string.Empty;
+            if (!File.Exists(projectFile.FullName))
+                return (0, string.Empty);
 
-            //load file
-            if (File.Exists(projectFile.FullName))
+            XDocument doc;
+            try { doc = XDocument.Load(projectFile.FullName); }
+            catch (Exception ex)
             {
-                text = File.ReadAllText(projectFile.FullName);
-
-                if (string.IsNullOrWhiteSpace(text))
-                {
-                    return (0, string.Empty);
-                }
+                Console.WriteLine($"Error parsing {projectFile.Name}: {ex.Message}");
+                return (0, string.Empty);
             }
 
-            var lines = text.Split(new[] { Environment.NewLine }, StringSplitOptions.None).ToList();
+            int count = doc.Descendants("ProjectReference")
+                .Count(r => r.Attribute("Include")?.Value?.Contains("Meadow.Foundation.Core") != true);
 
-            int count = 0;
-            string packageId = string.Empty;
-
-            foreach (var line in lines)
-            {
-                //does it reference another peripheral or a library
-                if (line.Contains("ProjectReference") &&
-                    line.Contains("Meadow.Foundation.Core") == false)
-                {
-                    count++;
-                }
-                else if (line.Contains("<PackageId>"))
-                {
-                    var index = line.IndexOf('>') + 1;
-                    packageId = line.Substring(index, line.IndexOf('<', index) - index);
-                }
-            }
+            var packageId = doc.Descendants("PackageId").FirstOrDefault()?.Value ?? string.Empty;
 
             return (count, packageId);
         }

--- a/Contribuir/Program.cs
+++ b/Contribuir/Program.cs
@@ -5,10 +5,21 @@ namespace Lectura
 {
     internal class Program
     {
-        static readonly string ROOT_DIRECTORY = @"h:\WL";
+        static string ROOT_DIRECTORY = @"h:\WL";
 
         static void Main(string[] args)
         {
+            if (args.Length > 0)
+                ROOT_DIRECTORY = args[0];
+            else if (Environment.GetEnvironmentVariable("WL_ROOT") is string envRoot)
+                ROOT_DIRECTORY = envRoot;
+            else
+            {
+                Console.WriteLine("Usage: Contribuir <wl-root-directory>");
+                Console.WriteLine("  Or set WL_ROOT environment variable");
+                return;
+            }
+
             Console.WriteLine("Hello, Contribuir - contributing.md writer");
 
             Repos.PopulateRepos();

--- a/Lanzamiento/Program.cs
+++ b/Lanzamiento/Program.cs
@@ -8,10 +8,10 @@ namespace Lanzamiento
 {
     internal class Program
     {
-        static readonly string ROOT_DEV_DIRECTORY = @"G:\2500";
-        static readonly string NUGET_DIRECTORY = @"G:\LocalNuget";
-        static readonly string VERSION = "2.5.0";
-        static readonly string NUGET_TOKEN = "";
+        static string ROOT_DEV_DIRECTORY = @"G:\2500";
+        static string NUGET_DIRECTORY = @"G:\LocalNuget";
+        static string VERSION = "2.5.0";
+        static string NUGET_TOKEN = "";
         static readonly string TIMESTAMP = "2023-10-31 6:52:00";
 
         static readonly bool testBuild = false;
@@ -21,8 +21,22 @@ namespace Lanzamiento
         static readonly bool publishNugets = true;
         static readonly bool pushVersionBranch = false;
 
-        static void Main(string[] _)
+        static void Main(string[] args)
         {
+            if (args.Length >= 4)
+            {
+                VERSION = args[0];
+                ROOT_DEV_DIRECTORY = args[1];
+                NUGET_DIRECTORY = args[2];
+                NUGET_TOKEN = args[3];
+            }
+            else
+            {
+                Console.WriteLine("Usage: Lanzamiento <version> <root-dev-directory> <nuget-directory> <nuget-token>");
+                Console.WriteLine("  Example: Lanzamiento 2.5.0 G:\\2500 G:\\LocalNuget abc123token");
+                return;
+            }
+
             var now = DateTime.Now;
 
             Console.WriteLine($"Hello Lanzamiento - {now}");

--- a/Lectura/Program.cs
+++ b/Lectura/Program.cs
@@ -7,10 +7,21 @@ namespace Lectura
 {
     internal class Program
     {
-        static readonly string ROOT_DIRECTORY = @"h:\WL";
+        static string ROOT_DIRECTORY = @"h:\WL";
 
         static void Main(string[] args)
         {
+            if (args.Length > 0)
+                ROOT_DIRECTORY = args[0];
+            else if (Environment.GetEnvironmentVariable("WL_ROOT") is string envRoot)
+                ROOT_DIRECTORY = envRoot;
+            else
+            {
+                Console.WriteLine("Usage: Lectura <wl-root-directory>");
+                Console.WriteLine("  Or set WL_ROOT environment variable");
+                return;
+            }
+
             Console.WriteLine("Hello, Lectura - readme writer");
 
             Repos.PopulateRepos();
@@ -94,9 +105,12 @@ namespace Lectura
 
             snipIndex += SNIP.Length;
 
+            if (snopIndex <= snipIndex)
+                return string.Empty;
+
             var rawText = text.Substring(snipIndex, snopIndex - snipIndex);
 
-            var lines = rawText.Split("\r\n");
+            var lines = rawText.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
 
             int whiteSpaceCount = 0;
             bool isStart = true;


### PR DESCRIPTION
- Lectura, Contribuir: replace hardcoded h:\WL with args[0] or WL_ROOT env var; require explicit root at runtime rather than silently using wrong path
- Lanzamiento: replace hardcoded G:\2500, G:\LocalNuget, VERSION, NUGET_TOKEN with required command-line args (version, root-dir, nuget-dir, token)
- ActionGen: replace string IndexOf/Substring XML parsing with XDocument.Load for PackageId and ProjectReference extraction in GetMetaData()
- Lectura.GetSnipSnop: fix CRLF-only split to handle LF line endings; add SNOP-before-SNIP bounds guard (same class of bug fixed in MFDriverSample)
